### PR TITLE
Adding support for autoCommit, including oracledb for tests & fixing null pointer.

### DIFF
--- a/lib/direct.js
+++ b/lib/direct.js
@@ -41,6 +41,9 @@ function connect(config) {
       throw new Error('To run oracle-client in direct or serve mode, you need to npm install oracledb');
     }
   }
+  if(config.autoCommit) {
+    oracledb.autoCommit = true;
+  }
   config.connectString = config.host + '/' + config.database;
   return new Promise((resolve, reject) => {
     oracledb.getConnection(config, (err, connection) => {
@@ -54,13 +57,17 @@ function connect(config) {
 }
 
 function objectify(result) {
-  return result.rows.map(row => {
-    return row.reduce((obj, colVal, colIndex) => {
-      var prop = changeCase.camelCase(result.metaData[colIndex].name);
-      obj[prop] = colVal;
-      return obj;
-    }, {});
-  });
+  if(result && result.rows) {
+    return result.rows.map(row => {
+      return row.reduce((obj, colVal, colIndex) => {
+        var prop = changeCase.camelCase(result.metaData[colIndex].name);
+        obj[prop] = colVal;
+        return obj;
+      }, {});
+    });
+  } else {
+    return result;
+  }
 }
 
 module.exports = () => { return {connect}; };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-mocha-reporter": "^1.1.5",
     "main-bower-files": "^2.11.1",
     "mocha": "^2.3.4",
+    "oracledb": "^1.11.0",
     "proxyquire": "^1.7.3",
     "run-sequence": "^1.1.5",
     "sinon": "^1.17.2",

--- a/test/unit/direct.spec.js
+++ b/test/unit/direct.spec.js
@@ -91,6 +91,16 @@ describe('oracleClient.direct()', () => {
               expect(res).to.eql([{id: 1, name: 'Johan'}]);
             });
         });
+        it('resolves the result object when no rows are returned', () => {
+          result.metaData = undefined;
+          result.rows = undefined;
+          result.rowsAffected = 1;
+          return connection
+            .execute('')
+            .then((res) => {
+              expect(res).to.eql({metaData: undefined, rows: undefined, rowsAffected: 1});
+            });
+        });
         it('rejects any errors', () => {
           var error = new Error('error');
           dbConn.execute.yields(error);


### PR DESCRIPTION
We needed to turn on autoCommit and noticed it was not supported. This change adds the config option `autoCommit: true`.

This also fixes the direct() unit tests by including oracledb as a dev dependency.

Finally, this fixes a null pointer that happens when there are no response rows. Insert queries were failing because the response did not contain rows, but instead returned the below object. Now, when there are no rows it just returns the entire response object.

Example insert response:
```
{ rowsAffected: 1,
  outBinds: undefined,
  rows: undefined,
  metaData: undefined }
```